### PR TITLE
Parser

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,10 +30,32 @@
                       cdkAutosizeMinRows="10"
                       cdkAutosizeMaxRows="20"
                       [formControl]="textareaFc"></textarea>
+                      <p></p>
+            <details>
+                <summary>
+                    <b>Textspezifikation</b>
+                </summary>
+                    <p>.tasks</p>
+                    <p>id type "label" (x,y)</p>
+                    <p>.events</p>
+                    <p>id type "label" (x,y)</p>
+                    <p>.gateways</p>
+                    <p>id type "label" (x,y)</p>
+                    <p>.edges</p>
+                    <p>idFrom idTo type "label"</p>
+                    <p></p>
+                    <p>Labels und Koordinaten sind jeweils optional</p>
+                    <p>types:</p>
+                    <p>tasks: sending, manual, usertask, service, businessrule, receiving, none</p>
+                    <p>events: start, end, intermediate</p>
+                    <p>gateways: or_split, or_join, and_split, and_join, xor_split, xor_join</p>
+                    <p>edges: sequenceflow, association, informationflow, defaultflow</p>
+            </details>
         </mat-form-field>
         <output-field buttonText="File download"
                       buttonIcon="download"
-                      [text]="textareaFc.value"></output-field>
+                      [text]="textareaFc.value">
+        </output-field>
     </div>
 
     <!--  Footer  -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -44,9 +44,10 @@
                     <p>.edges</p>
                     <p>idFrom idTo type "label"</p>
                     <p></p>
-                    <p>Labels und Koordinaten sind jeweils optional</p>
+                    <p>Labels und Koordinaten sind immer optional</p>
+                    <p>bei Tasks ist auch der Typ optional</p>
                     <p>types:</p>
-                    <p>tasks: sending, manual, usertask, service, businessrule, receiving, none</p>
+                    <p>tasks: sending, manual, usertask, service, businessrule, receiving</p>
                     <p>events: start, end, intermediate</p>
                     <p>gateways: or_split, or_join, and_split, and_join, xor_split, xor_join</p>
                     <p>edges: sequenceflow, association, informationflow, defaultflow</p>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,7 +34,6 @@ export class AppComponent implements OnDestroy {
             pipe(debounceTime(400)).
             subscribe((val) => this.textareaFc.setValue(val));
 
-
         // this.textareaFc.setValue(`Your advertising could be here`);
 
 
@@ -123,7 +122,7 @@ this.textareaFc.setValue(s);
 
     ngOnDestroy(): void {
         this._sub.unsubscribe();
-        //this._sub1.unsubscribe();
+        this._sub1.unsubscribe();
     }
 
     private processSourceChange(newSource: string) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnDestroy {
     mode = "free dragging"
     public textareaFc: FormControl;
     private _sub: Subscription;
-    //private _sub1: Subscription;
+    private _sub1: Subscription;
     private result: any;
     graphIsValid: boolean = false;
 
@@ -28,11 +28,11 @@ export class AppComponent implements OnDestroy {
     ) {
         this.textareaFc = new FormControl();
         this._sub = this.textareaFc.valueChanges
-            .pipe(debounceTime(400))
+            .pipe(debounceTime(1000))
             .subscribe((val) => this.processSourceChange(val));
-        /*this._sub1 = this._parserService.positionChange.
+        this._sub1 = this._parserService.positionChange.
             pipe(debounceTime(400)).
-            subscribe((val) => this.textareaFc.setValue(val));*/
+            subscribe((val) => this.textareaFc.setValue(val));
 
 
         // this.textareaFc.setValue(`Your advertising could be here`);
@@ -42,25 +42,25 @@ export class AppComponent implements OnDestroy {
 let s : String = '.events\n'+
 'e1 start "E1 Start1"\n'+
 'e2 start "E2 Start2"\n'+
-'e3 end "E3 Ende"\n'+
+'e3 end\n'+
 '\n'+
-'.activities\n'+
-'t1 none "T1"\n'+
-'t2 none "T2"\n'+
+'.tasks\n'+
+'t1 manual "t1"\n'+
+'t2 usertask "T2"\n'+
 't3 none "T3"\n'+
-'t4 none "T4"\n'+
-'t5 none "T5"\n'+
-'t6 none "T6"\n'+
-'t7 none "T7"\n'+
-'t8 none "T8"\n'+
-'t9 none "T9"\n'+
-'t10 none "T10"\n'+
-'t11 none "T11"\n'+
-'t12 none "T12"\n'+
-'t13 none "T13"\n'+
-'t14 none "T14"\n'+
-'t15 none "T15"\n'+
-'t16 none "T16"\n'+
+'t4 usertask "T4"\n'+
+'t5 usertask "T5"\n'+
+'t6 usertask "T6"\n'+
+'t7 usertask "T7"\n'+
+'t8 usertask "T8"\n'+
+'t9 usertask "T9"\n'+
+'t10 manual "T10"\n'+
+'t11 service "T11"\n'+
+'t12 usertask "T12"\n'+
+'t13 manual "T13"\n'+
+'t14 usertask "T14"\n'+
+'t15 manual "T15"\n'+
+'t16 service "T16"\n'+
 '\n'+
 '.gateways\n'+
 'g1J or_join "G1J"\n'+
@@ -73,48 +73,48 @@ let s : String = '.events\n'+
 'g5S and_split "G5S"\n'+
 'g5J and_join "G5J"\n'+
 'g6S xor_split "G6S"\n'+
-'g6J xor_join "G6J"\n'+
-'g7S or_split "G7S"\n'+
-'g7J or_join "G7J"\n'+
+'g6J xor_join\n'+
+'g7S or_split\n'+
+'g7J or_join\n'+
 '\n'+
-'.sequences\n'+
-'a1 sequenceflow "a1" e1 t1\n'+      
-'a2 sequenceflow "a2" t1 g1J\n'+ 
-'a3 sequenceflow "a3" e2 g1J\n'+ 
-'a4 sequenceflow "a4" g1J t2\n'+
-'a5 sequenceflow "a5" t2 g2S\n'+
-'a6 sequenceflow "a6" g2S t3\n'+
-'a7 sequenceflow "a7" t3 g3S\n'+
-'a8 sequenceflow "a8" g3S t6\n'+
-'a9 sequenceflow "a9" t6 g6S\n'+
-'a10 sequenceflow "a10" g6S t7\n'+
-'a11 sequenceflow "a11" g6S t8\n'+
-'a12 sequenceflow "a12" t7 t15\n'+
-'a13 sequenceflow "a13" t8 t16\n'+
-'a15 sequenceflow "a15" t15 g6J\n'+
-'a16 sequenceflow "a16" t16 g6J\n'+
-'a14 sequenceflow "a14" g6J g3J\n'+
-'a17 sequenceflow "a17" g3S t9\n'+
-'a18 sequenceflow "a18" t9 g7S\n'+
-'a19 sequenceflow "a19" g7S t10\n'+
-'a20 sequenceflow "a20" g7S t11\n'+
-'a21 sequenceflow "a21" t10 g7J\n'+
-'a22 sequenceflow "a22" t11 g7J\n'+
-'a23 sequenceflow "a23" g7J g3J\n'+
-'a24 sequenceflow "a24" g2S g4S\n'+
-'a25 sequenceflow "a25" g4S t4\n'+
-'a26 sequenceflow "a26" t4 t12\n'+
-'a27 sequenceflow "a27" t12 g4J\n'+
-'a28 sequenceflow "a28" g4S t5\n'+
-'a29 sequenceflow "a29" t5 g5S\n'+
-'a30 sequenceflow "a30" g5S t13\n'+
-'a31 sequenceflow "a31" g5S t14\n'+
-'a32 sequenceflow "a32" t13 g5J\n'+
-'a33 sequenceflow "a33" t14 g5J\n'+
-'a34 sequenceflow "a34" g5J g4J\n'+
-'a35 sequenceflow "a35" g3J g2J\n'+
-'a36 sequenceflow "a36" g4J g2J\n'+
-'a37 sequenceflow "a37" g2J e3';
+'.edges\n'+
+'e1 t1 sequenceflow\n'+      
+'t1 g1J sequenceflow\n'+ 
+'e2 g1J sequenceflow "a3"\n'+ 
+'g1J t2 sequenceflow\n'+
+'t2 g2S sequenceflow\n'+
+'g2S t3 sequenceflow\n'+
+'t3 g3S sequenceflow\n'+
+'g3S t6 sequenceflow\n'+
+'t6 g6S sequenceflow\n'+
+'g6S t7 sequenceflow\n'+
+'g6S t8 sequenceflow "t8"\n'+
+'t7 t15 sequenceflow\n'+
+'t8 t16 sequenceflow\n'+
+'t15 g6J sequenceflow\n'+
+'t16 g6J sequenceflow\n'+
+'g6J g3J sequenceflow\n'+
+'g3S t9 sequenceflow\n'+
+'t9 g7S sequenceflow\n'+
+'g7S t10 sequenceflow\n'+
+'g7S t11 sequenceflow\n'+
+'t10 g7J sequenceflow\n'+
+'t11 g7J sequenceflow\n'+
+'g7J g3J sequenceflow\n'+
+'g2S g4S sequenceflow\n'+
+'g4S t4 sequenceflow\n'+
+'t4 t12 sequenceflow\n'+
+'t12 g4J sequenceflow\n'+
+'g4S t5 sequenceflow\n'+
+'t5 g5S sequenceflow\n'+
+'g5S t13 sequenceflow\n'+
+'g5S t14 sequenceflow\n'+
+'t13 g5J sequenceflow\n'+
+'t14 g5J sequenceflow\n'+
+'g5J g4J sequenceflow\n'+
+'g3J g2J sequenceflow\n'+
+'g4J g2J sequenceflow\n'+
+'g2J e3 sequenceflow';
 
 console.log(s);
 this.textareaFc.setValue(s);
@@ -134,7 +134,7 @@ this.textareaFc.setValue(s);
             if (this.result.nodes.length === 0)
                 this.result = BpmnGraph.anotherMonsterGraph();
             this._displayService.display(this.result);
-
+            this._parserService.afterSugiyamaLayout(this.result,newSource);
         }
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,11 +46,11 @@ let s : String = '.events\n'+
 '.tasks\n'+
 't1 manual "t1"\n'+
 't2 usertask "T2"\n'+
-'t3 none "T3"\n'+
+'t3 "T3"\n'+
 't4 usertask "T4"\n'+
-'t5 usertask "T5"\n'+
+'t5\n'+
 't6 usertask "T6"\n'+
-'t7 usertask "T7"\n'+
+'t7 "T7"\n'+
 't8 usertask "T8"\n'+
 't9 usertask "T9"\n'+
 't10 manual "T10"\n'+

--- a/src/app/components/display-draggable-graph/display-draggable-graph.component.ts
+++ b/src/app/components/display-draggable-graph/display-draggable-graph.component.ts
@@ -71,7 +71,6 @@ export class DisplayDraggableGraphComponent
         }
     }
     ngAfterViewInit(): void {
-        console.log("init");
         this._sub = this._displayService.diagram$.subscribe((bpmnGraph) => {
             if (bpmnGraph == undefined) return;
             if (bpmnGraph.isEmpty()) return;

--- a/src/app/components/display-draggable-graph/display-draggable-graph.component.ts
+++ b/src/app/components/display-draggable-graph/display-draggable-graph.component.ts
@@ -71,6 +71,7 @@ export class DisplayDraggableGraphComponent
         }
     }
     ngAfterViewInit(): void {
+        console.log("init");
         this._sub = this._displayService.diagram$.subscribe((bpmnGraph) => {
             if (bpmnGraph == undefined) return;
             if (bpmnGraph.isEmpty()) return;
@@ -89,9 +90,9 @@ export class DisplayDraggableGraphComponent
             Utility.removeAllChildren(this.drawingArea.nativeElement);
             const svg =this._draggableGraph.svgManager.getSvg()
             this.drawingArea.nativeElement.appendChild(svg);
-            this._layoutService.zoomViewToSvg(svg, this.drawingArea.nativeElement,this.rootSvg.nativeElement)
-
+            this._layoutService.zoomViewToSvg(svg, this.drawingArea.nativeElement,this.rootSvg.nativeElement);
         });
+
     }
 
     ngOnDestroy(): void {

--- a/src/app/components/display-reorder-graph/display-reorder-graph.component.ts
+++ b/src/app/components/display-reorder-graph/display-reorder-graph.component.ts
@@ -42,10 +42,11 @@ export class DisplayReorderGraphComponent implements OnDestroy, AfterViewInit {
   ) {}
 
   onReset(){
-    this.ngAfterViewInit()
+    this.ngAfterViewInit();
 }
   ngAfterViewInit(): void {
       this._sub = this._displayService.diagram$.subscribe((graph) => {
+
           this.bpmnGraph = graph;
           this._layoutService.applySugiyama(this.bpmnGraph)
           if (this.drawingArea == undefined || this.rootSvg == undefined) return;
@@ -75,10 +76,11 @@ export class DisplayReorderGraphComponent implements OnDestroy, AfterViewInit {
                         edgeEnds.push(corner)
                     }
                 }
+                if(!(nodes.length == 0 && dummyNodes.length ==0 && edgeStarts.length ==0 && edgeEnds.length ==0)){
+                    this._parserService.positionOfNodesAndEdgesChanged(nodes,dummyNodes,edgeStarts,edgeEnds)
+                }
             }
-            if(!(nodes.length == 0 && dummyNodes.length ==0 && edgeStarts.length ==0 && edgeEnds.length ==0)){
-                this._parserService.positionOfNodesAndEdgesChanged(nodes,dummyNodes,edgeStarts,edgeEnds)
-            }
+          
           }
           const bpmnGraphSvg = this.bpmnGraph.svgManager.getNewSvg()
           for (const node of this.bpmnGraph.nodes) {
@@ -118,7 +120,9 @@ export class DisplayReorderGraphComponent implements OnDestroy, AfterViewInit {
         this.drawingArea.nativeElement.appendChild(dragHandleSvgs);
         this._layoutService.zoomViewToSvg(bpmnGraphSvg, this.drawingArea.nativeElement,this.rootSvg.nativeElement)
       });
-  }
+      this._parserService.resetCoordinates();
+
+    }
 
   ngOnDestroy(): void {
       this._sub?.unsubscribe();

--- a/src/app/components/display-reorder-graph/display-reorder-graph.component.ts
+++ b/src/app/components/display-reorder-graph/display-reorder-graph.component.ts
@@ -78,8 +78,9 @@ export class DisplayReorderGraphComponent implements OnDestroy, AfterViewInit {
                 }
                 if(!(nodes.length == 0 && dummyNodes.length ==0 && edgeStarts.length ==0 && edgeEnds.length ==0)){
                     this._parserService.positionOfNodesAndEdgesChanged(nodes,dummyNodes,edgeStarts,edgeEnds)
-                }
+                }   
             }
+          
           
           }
           const bpmnGraphSvg = this.bpmnGraph.svgManager.getNewSvg()

--- a/src/app/components/input-field/input-field.component.ts
+++ b/src/app/components/input-field/input-field.component.ts
@@ -47,10 +47,12 @@ export class InputFieldComponent {
                 if (validated) {
                     // console.log("validation successful");
                     this.newInputEvent.emit(input);
+                } else {
+                    this.displayErrorService.displayError("Fehler beim Textformat. bitte Spezifikation beachten");
+                    return;
+                 }
                 }
 
-            }
-        })
+            })
+        }
     }
-
-}

--- a/src/app/components/output-field/output-field.component.ts
+++ b/src/app/components/output-field/output-field.component.ts
@@ -129,7 +129,7 @@ export class OutputFieldComponent {
                     let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
                   
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
-                        matchLineNew = matchLine.concat(" "+newCoordString);
+                        matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString);
                     }
                    
                     text[index] = matchLineNew;
@@ -147,7 +147,7 @@ export class OutputFieldComponent {
 
                     let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString1 + " " + newCoordString2);
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
-                        matchLineNew = matchLine.concat(" "+newCoordString1 + " " + newCoordString2);
+                        matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString1 + " " + newCoordString2);
                     }
                     text[index] = matchLineNew;
             }}

--- a/src/app/components/output-field/output-field.component.ts
+++ b/src/app/components/output-field/output-field.component.ts
@@ -37,13 +37,15 @@ export class OutputFieldComponent {
         switch (type) {
             case 'bpmn': {
                 
-                textToExport = this.text;
-                if (textToExport) {
-                    if (!this.formValidationService.validateFormat(textToExport)) {
-                        this.displayErrorService.displayError("BPMN-Format ist verletzt; nicht exportierbar");
+                let diagram = this.displayService.diagram;
+                if (this.text) {
+                    let outputText = this.addCoordinates(diagram);
+
+                    if (!this.formValidationService.validateFormat(outputText)) {
+                        this.displayErrorService.displayError("BPMN-Textformat ist verletzt; nicht exportierbar");
                         return;
                     }
-
+                    textToExport = outputText;
                 };
                 break;
             }
@@ -124,4 +126,44 @@ export class OutputFieldComponent {
         return graph
     }
 
-}
+    private addCoordinates(diagram: BpmnGraph): string {
+
+        let text = this.text?.split("\n");
+        
+        for (const node of diagram.nodes) {
+            if(text) {
+                let newCoordString = "(" + node.getPos().x + "," + node.getPos().y + ")";
+                let matchLine = text.find(line => line.startsWith(node.id));
+                if(matchLine != undefined) {
+                    let index = text.indexOf(matchLine);
+                    let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
+                  
+                    if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
+                        matchLineNew = matchLine.concat(" "+newCoordString);
+                    }
+                   
+                    text[index] = matchLineNew;
+                
+            }}
+        }
+            for (const edge of diagram.edges){
+                if(text) {
+                let newCoordString1 = "(" + edge.from.x + "," + edge.from.y + ")";
+                let newCoordString2 = "(" + edge.to.x + "," + edge.to.y + ")";
+                let matchLine = text.find(line => line.startsWith(edge.id));
+
+                if(matchLine != undefined) {
+                    let index = text.indexOf(matchLine);
+
+                    let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString1 + " " + newCoordString2);
+                    if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
+                        matchLineNew = matchLine.concat(" "+newCoordString1 + " " + newCoordString2);
+                    }
+                    text[index] = matchLineNew;
+            }}
+
+        }
+        if(text) {
+            return text.join("\n");
+        }else return "";
+}}

--- a/src/app/services/display.service.ts
+++ b/src/app/services/display.service.ts
@@ -33,4 +33,8 @@ export class DisplayService implements OnDestroy {
         this._diagram$.next(bpmnGraph);
     }
 
+    public displayOnly(bpmnGraph: BpmnGraph){
+        this._diagram$.next(bpmnGraph);
+    }
+
 }

--- a/src/app/services/form-validation.service.ts
+++ b/src/app/services/form-validation.service.ts
@@ -13,32 +13,26 @@ export class FormValidationService {
     }
 
     validateFormat(input: string): boolean {
-        if (!input.includes(".tasks" && ".edges")) {
-            this.displayErrorService.displayError("wrong format");
-            //console.log("wrong format");
-            return false;
-        } else {
+        if (input.includes(".tasks")){
             if (!this.validateCategory("tasks", input)) {
                 return false;
             }
+        }
+        if(input.includes(".edges")){
             if (!this.validateCategory("edges", input)) {
                 return false;
             }
-            ;
-
-            if (input.includes(".events")) {
-                if (!this.validateCategory("events", input)) {
-                    return false;
-                }
-            }
-            if (input.includes(".gateways")) {
-                if (!this.validateCategory("gateways", input)) {
-                    return false;
-                }
-            }
-
-
         }
+        if (input.includes(".events")) {
+            if (!this.validateCategory("events", input)) {
+                return false;
+                }
+            }
+        if (input.includes(".gateways")) {
+            if (!this.validateCategory("gateways", input)) {
+                return false;
+                }
+            }
         return true;
     }
 
@@ -46,8 +40,8 @@ export class FormValidationService {
         let regexp: RegExp;
         switch (category) {
 
-            case "tasks": regexp = /^[\w]+( "[\w ]*")? (Sending|Manual|Service|BusinessRule|Receiving|UserTask|none)(?: \([0-9]*,[0-9]*\))?/i; break;
-            case "edges": regexp = /^[\w]+ [\w]+( "[\w ]*")? (SequenceFlow|Association|InformationFlow)(?: \([0-9]*,[0-9]*\))?/i; break;
+            case "tasks": regexp = /^[\w]+( "[\w ]*")? (Sending|Manual|Service|BusinessRule|Receiving|UserTask)? (?: \([0-9]*,[0-9]*\))?/i; break;
+            case "edges": regexp = /^[\w]+ [\w]+( "[\w ]*")? (SequenceFlow|Association|InformationFlow|DefaultFlow)(?: \([0-9]*,[0-9]*\))?/i; break;
             case "events": regexp = /^[\w]+( "[\w ]*")? (Start|End|Intermediate)(?: \([0-9]*,[0-9]*\))?/i; break;
             case "gateways": regexp = /^[\w]+( "[\w ]*")? (XOR_SPLIT|XOR_JOIN|AND_SPLIT|AND_JOIN|OR_SPLIT|OR_JOIN)(?: \([0-9]*,[0-9]*\))?/i; break;
             default: return false;

--- a/src/app/services/form-validation.service.ts
+++ b/src/app/services/form-validation.service.ts
@@ -13,16 +13,15 @@ export class FormValidationService {
     }
 
     validateFormat(input: string): boolean {
-        //console.log(input);
-        if (!input.includes(".activities" && ".sequences")) {
+        if (!input.includes(".tasks" && ".edges")) {
             this.displayErrorService.displayError("wrong format");
             //console.log("wrong format");
             return false;
         } else {
-            if (!this.validateCategory("activities", input)) {
+            if (!this.validateCategory("tasks", input)) {
                 return false;
             }
-            if (!this.validateCategory("sequences", input)) {
+            if (!this.validateCategory("edges", input)) {
                 return false;
             }
             ;
@@ -46,14 +45,11 @@ export class FormValidationService {
     private validateCategory(category: string, input: string): boolean {
         let regexp: RegExp;
         switch (category) {
-            //bei Aktivitäten und Events müssen wir uns noch auf Typen einigen
-            //die für die Eingabe gültig sind, dann kann ich sie hier mit überprüfen
-            //aktuell sind nur die Typen für Gateways eindeutig definiert
 
-            case "activities": regexp = /^[\w]+ (None|Sending|Manual|Service|BusinessRule|Receiving|UserTask) "[\w ]*"(?: \([0-9]*,[0-9]*\))?/i; break;
-            case "sequences": regexp = /^[\w]+ (SequenceFlow|Association|InformationFlow) "[\w ]*" [\w]+ [\w]+(?: \([0-9]*,[0-9]*\))?/i; break;
-            case "events": regexp = /^[\w]+ (Start|End|Intermediate) "[\w ]*"(?: \([0-9]*,[0-9]*\))?/i; break;
-            case "gateways": regexp = /^[\w]+ (XOR_SPLIT|XOR_JOIN|AND_SPLIT|AND_JOIN|OR_SPLIT|OR_JOIN) "[\w ]*"(?: \([0-9]*,[0-9]*\))?/i; break;
+            case "tasks": regexp = /^[\w]+( "[\w ]*")? (Sending|Manual|Service|BusinessRule|Receiving|UserTask|none)(?: \([0-9]*,[0-9]*\))?/i; break;
+            case "edges": regexp = /^[\w]+ [\w]+( "[\w ]*")? (SequenceFlow|Association|InformationFlow)(?: \([0-9]*,[0-9]*\))?/i; break;
+            case "events": regexp = /^[\w]+( "[\w ]*")? (Start|End|Intermediate)(?: \([0-9]*,[0-9]*\))?/i; break;
+            case "gateways": regexp = /^[\w]+( "[\w ]*")? (XOR_SPLIT|XOR_JOIN|AND_SPLIT|AND_JOIN|OR_SPLIT|OR_JOIN)(?: \([0-9]*,[0-9]*\))?/i; break;
             default: return false;
         }
 
@@ -78,7 +74,7 @@ export class FormValidationService {
                 pos++;
             }
         }
-        //console.log(category + " validated");
+        console.log(category + " validated");
         return true;
         }
 

--- a/src/app/services/form-validation.service.ts
+++ b/src/app/services/form-validation.service.ts
@@ -40,7 +40,7 @@ export class FormValidationService {
         let regexp: RegExp;
         switch (category) {
 
-            case "tasks": regexp = /^[\w]+( "[\w ]*")? (Sending|Manual|Service|BusinessRule|Receiving|UserTask)? (?: \([0-9]*,[0-9]*\))?/i; break;
+            case "tasks": regexp = /^[\w]+( "[\w ]*")? (Sending|Manual|Service|BusinessRule|Receiving|UserTask)?(?: \([0-9]*,[0-9]*\))?/i; break;
             case "edges": regexp = /^[\w]+ [\w]+( "[\w ]*")? (SequenceFlow|Association|InformationFlow|DefaultFlow)(?: \([0-9]*,[0-9]*\))?/i; break;
             case "events": regexp = /^[\w]+( "[\w ]*")? (Start|End|Intermediate)(?: \([0-9]*,[0-9]*\))?/i; break;
             case "gateways": regexp = /^[\w]+( "[\w ]*")? (XOR_SPLIT|XOR_JOIN|AND_SPLIT|AND_JOIN|OR_SPLIT|OR_JOIN)(?: \([0-9]*,[0-9]*\))?/i; break;

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -14,15 +14,14 @@ import { ParserService } from './parser.service';
     providedIn: 'root',
 })
 export class LayoutService {
-   
-    private _afterSugiyamaLayoutCallback = () => {}
-    public set afterSugiyamaLayoutCallback(value:()=>any) {
+
+    private _afterSugiyamaLayoutCallback = (bpmnGraph:BpmnGraph,text:string) => {}
+    public set afterSugiyamaLayoutCallback(value:(bpmnGraph: BpmnGraph,text:string)=>any) {
         this._afterSugiyamaLayoutCallback = value;
     }
     applySugiyama(bpmnGraph: BpmnGraph) {
         this.getSugiyamaResult(bpmnGraph);
         this.setCoordinates(bpmnGraph);
-        this._afterSugiyamaLayoutCallback()
     }
     getSnapsForNode(): SnapElement[] {
         const snaps = [];

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -42,7 +42,7 @@ export class ParserService {
     
     private text:string[];
     private result!: BpmnGraph;
-    seqCount: number;
+    private seqCount: number;
 
     constructor(private displayService:DisplayService,
         private displayerrorService: DisplayErrorService, 
@@ -64,7 +64,6 @@ export class ParserService {
 
     positionOfNodesAndEdgesChanged(nodes: BpmnNode[], dummyNodes: BpmnDummyEdgeCorner[], edgeStarts: BpmnEdgeCorner[], edgeEnds: BpmnEdgeCorner[]) {
         //@Vanessa
-        console.log("positionMedthod");
         for (const node of nodes) {
 
             if (this.text != []) {
@@ -79,7 +78,7 @@ export class ParserService {
                     }
                    
                     this.text[index] = matchLineNew;
-                    console.log("new node position:"+ matchLineNew);
+                    //console.log("new node position:"+ matchLineNew);
                     
                 }
                 
@@ -156,7 +155,7 @@ export class ParserService {
         this.displayService.displayOnly(bpmnGraph);
     }
     
-    //called when the "reset" button is pushed
+    //called when sugiyama layout is selected
     resetCoordinates() {
         for(let i = 0; i < this.text.length; i++) {
             console.log(this.text[i].match(/\(-?[0-9]*,-?[0-9]*\)/));
@@ -169,12 +168,8 @@ export class ParserService {
     }
 
     parse(text: string): BpmnGraph | undefined {
-       
+
         console.log("parsing");
-        if (!this.formValidationService.validateFormat(text)) {
-            this.displayerrorService.displayError("Fehler beim Textformat. bitte Spezifikation beachten");
-            return;
-        } else {
         
         const lines = text.split('\n');
         this.text = lines; 
@@ -248,10 +243,10 @@ export class ParserService {
         }
      
     }
-}
 
 
     private parseTasks(line: string): BpmnNode | undefined {
+
         let description = "";
         if(line.includes('"')) {
             description = line.split('"')[1];
@@ -269,14 +264,11 @@ export class ParserService {
             return;
         }
         let activity = new BpmnTask(name);
-        console.log(lineSplit);
+        //console.log(lineSplit);
 
-        //if line ends with a \n
-        let type = lineSplit[1];
-        switch (type.toLowerCase()) {
-            case ("none"):
-                activity = new BpmnTask(name);
-                break;
+        if(lineSplit[1] && !lineSplit[1].startsWith("(") && !(lineSplit[1] === description)){
+            let type = lineSplit[1];
+            switch (type.toLowerCase()) {
             case ("sending"):
                 activity = new BpmnTaskSending(name);
                 break;
@@ -296,8 +288,8 @@ export class ParserService {
                 activity = new BpmnTaskUserTask(name);
                 break;
             default: 
-                this.displayerrorService.displayError("invalid task type "+ type);
-        }
+                this.displayerrorService.displayError("Ungültiger Task Typ"+ type);
+        }}
 
         if(description) activity.label = description;
 
@@ -339,7 +331,7 @@ export class ParserService {
                 event = new BpmnEventEnd(name);
                 break;
             default: 
-                this.displayerrorService.displayError("invalid event type '" + type + "'");
+                this.displayerrorService.displayError("Ungültiger Event Typ " + type + "'");
         }
 
         if(description) event.label = description;
@@ -387,7 +379,7 @@ export class ParserService {
                 gateway = new BpmnGatewaySplitXor(name);
                 break;
             default: 
-                this.displayerrorService.displayError("invalid gateway type " + type); 
+                this.displayerrorService.displayError("Ungültiger Gateway Typ " + type); 
         }
         if(description) gateway.label = description;
         return gateway;
@@ -430,7 +422,7 @@ export class ParserService {
                             case("sequenceflow"): sequence = new BpmnEdge(name,node1,node2); break;
                             case("association"): sequence = new BpmnEdgeAssociation(name,node1,node2); break;
                             case("informationflow"): sequence = new BpmnEdgeMessageflow(name,node1,node2); break;
-                            default: this.displayerrorService.displayError("invalid connector type "+ type + node1.id + node2.id);
+                            default: this.displayerrorService.displayError("Ungültiger Edge Typ "+ type + node1.id + node2.id);
                         }
                         if(description) sequence.labelMid = description;
                         

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -64,7 +64,7 @@ export class ParserService {
 
     positionOfNodesAndEdgesChanged(nodes: BpmnNode[], dummyNodes: BpmnDummyEdgeCorner[], edgeStarts: BpmnEdgeCorner[], edgeEnds: BpmnEdgeCorner[]) {
         //@Vanessa
-
+        console.log("positionMedthod");
         for (const node of nodes) {
 
             if (this.text != []) {
@@ -75,7 +75,7 @@ export class ParserService {
                     let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
                   
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
-                        matchLineNew = matchLine.concat(" "+newCoordString);
+                        matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString);
                     }
                    
                     this.text[index] = matchLineNew;
@@ -90,15 +90,13 @@ export class ParserService {
 
                 if(matchLine != undefined) {
                     let index = this.text.indexOf(matchLine);
-                    //zweite (to) node auswählen 
-                    //dahinter: wenn schon was ist dann replacen. ansonsten neu rein
 
                     let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
-                        matchLineNew = matchLine.concat(" "+newCoordString);
+                        matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString);
                     }
                     this.text[index] = matchLineNew;
-                    console.log("new incoming edge position:" + matchLineNew);
+                    //console.log("new incoming edge position:" + matchLineNew);
             }
 
         }
@@ -109,15 +107,13 @@ export class ParserService {
 
             if(matchLine != undefined) {
                 let index = this.text.indexOf(matchLine);
-                //erste (from) node auswählen
-                //dahinter: wenn schon was ist dann replacen. ansonsten neu rein
                 let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
                 const matches = matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/);
                 if(matches === null) {
                     matchLineNew = matchLine.concat(" "+newCoordString);
                 }
                 this.text[index] = matchLineNew;
-                console.log("new outgoing edge position:" + matchLineNew);
+                //console.log("new outgoing edge position:" + matchLineNew);
         }
 
         }
@@ -160,6 +156,17 @@ export class ParserService {
         this.displayService.displayOnly(bpmnGraph);
     }
     
+    //called when the "reset" button is pushed
+    resetCoordinates() {
+        for(let i = 0; i < this.text.length; i++) {
+            console.log(this.text[i].match(/\(-?[0-9]*,-?[0-9]*\)/));
+            this.text[i] = this.text[i].replace(/\(-?[0-9]*,-?[0-9]*\)/,"");
+            console.log(this.text[i]);
+        }
+        let emitText = this.text.join("\n");
+
+        this.positionChange.emit(emitText);
+    }
 
     parse(text: string): BpmnGraph | undefined {
        
@@ -262,6 +269,7 @@ export class ParserService {
             return;
         }
         let activity = new BpmnTask(name);
+        console.log(lineSplit);
 
         //if line ends with a \n
         let type = lineSplit[1];
@@ -359,7 +367,6 @@ export class ParserService {
         let gateway = new BpmnGateway(name);
 
         let type = lineSplit[1];
-        console.log(lineSplit);
         switch (type.toLowerCase()) {
             case ("and_join"):
                 gateway = new BpmnGatewayJoinAnd(name);

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -264,9 +264,8 @@ export class ParserService {
             return;
         }
         let activity = new BpmnTask(name);
-        //console.log(lineSplit);
 
-        if(lineSplit[1] && !lineSplit[1].startsWith("(") && !(lineSplit[1] === description)){
+        if(lineSplit[1] && !lineSplit[1].startsWith("(") && !(lineSplit[1] === description.split(" ").join(""))){
             let type = lineSplit[1];
             switch (type.toLowerCase()) {
             case ("sending"):
@@ -288,7 +287,7 @@ export class ParserService {
                 activity = new BpmnTaskUserTask(name);
                 break;
             default: 
-                this.displayerrorService.displayError("Ungültiger Task Typ"+ type);
+                this.displayerrorService.displayError("Ungültiger Task Typ "+ type);
         }}
 
         if(description) activity.label = description;

--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -68,11 +68,15 @@ export class ParserService {
 
             if (this.text != []) {
                 let newCoordString = "(" + node.getPos().x + "," + node.getPos().y + ")";
+                if(!node.getPos().y) {
+                    newCoordString = "(" + node.getPos().x + "," + 0 + ")";
+                }
                 let matchLine = this.text.find(line => line.startsWith(node.id));
                 if(matchLine != undefined) {
                     let index = this.text.indexOf(matchLine);
+
                     let matchLineNew = matchLine.replace(/\(-?[0-9]*,-?[0-9]*\)/,newCoordString);
-                  
+
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
                         matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString);
                     }
@@ -94,6 +98,8 @@ export class ParserService {
                     if(matchLine.match(/\(-?[0-9]*,-?[0-9]*\)/) === null) {
                         matchLineNew = matchLine.replace(/[\n\r]/,"").concat(" "+newCoordString);
                     }
+
+
                     this.text[index] = matchLineNew;
                     //console.log("new incoming edge position:" + matchLineNew);
             }

--- a/src/assets/samplegraph.txt
+++ b/src/assets/samplegraph.txt
@@ -1,30 +1,28 @@
 .events
-e1 start "Am Start" (60,190)
-e2 intermediate "BpmnEventIntermediate" (850,190)
-e3 end "BpmnEventEnd" (1600,190)
-ee3 end "ende gelaende" (1600,190)
+e1 start "Am Start"
+e2 intermediate "BpmnEventIntermediate"
+e3 end "BpmnEventEnd"
+ee3 end "ende gelaende"
 
-.activities
-t1 service "BpmnTaskService" (442,60)
-t2 manual "BpmnTaskManual" (442,320)
-t3 usertask "BpmnTaskUser" (1225,190)
-tb2 businessrule "BpmnTaskBusinessRule"
+.tasks
+t1 service "BpmnTaskService"
+t2 manual "BpmnTaskManual"
+t3 usertask "BpmnTaskUser"
 
 .gateways 
-g1 or_split "BpmnGateway" (210,190)
-g2 or_join "BpmnGateway" (675,190)
+g1 or_split
+g2 or_join
 
-.sequences
-coupou sequenceflow "1vvv" ee3 e3
-connector sequenceflow "1" e1 g1 
-pfeil sequenceflow "p2" g1 t1
-connector2 sequenceflow "p3" g1 t2 (210,320)
-connector3 sequenceflow "a4" t1 g2 (675,60)
-connector4 sequenceflow "a5" t2 g2 (675,320)
-connector5 sequenceflow "a6" g2 e2 
-connector6 sequenceflow "a7" e2 t3
-connector7 sequenceflow "a8" t3 e3
+.edges
+ee3 e3 sequenceflow "1vvv" 
+e1 g1 sequenceflow ""
+g1 t1 sequenceflow "p2" 
+g1 t2 sequenceflow "p3"
+t1 g2 sequenceflow "a4"
+t2 g2 sequenceflow "a5"
+g2 e2 sequenceflow "a6" 
+e2 t3 sequenceflow "a7" 
+t3 e3 sequenceflow "a8" 
 
- 
 
 

--- a/src/assets/valid-graphs/BeispielSeite27_E2_T9_G8_A22.txt
+++ b/src/assets/valid-graphs/BeispielSeite27_E2_T9_G8_A22.txt
@@ -2,7 +2,7 @@
 e1 start "e1"
 e2 end "e2"
 
-.activities
+.tasks
 t1 none "Reise planen"
 t2 none "Antrag stellen"
 t3 none " Reise genehmigen"
@@ -14,35 +14,35 @@ t8 none "Vorauszahlung durchfuehren"
 t9 none "Reise durchfuehren"
 
 .gateways 
-g1 xor_join ""
-g2 xor_split ""
-g3 and_split ""
-g4 and_join ""
-g5 or_split ""
-g6 or_join ""
-g7 xor_split ""
-g8 xor_join ""
+g1 xor_join
+g2 xor_split
+g3 and_split
+g4 and_join
+g5 or_split
+g6 or_join
+g7 xor_split
+g8 xor_join
 
-.sequences
-a1 sequenceflow "a1" e1 t1
-a2 sequenceflow "a2" t1 g1
-a3 sequenceflow "a3" g1 t2
-a4 sequenceflow "a4" t2 g2
-a5 sequenceflow "a5" g2 t3
-a6 sequenceflow "a6" t3 g3
-a7 sequenceflow "a7" g2 g1
-a8 sequenceflow "a8" g3 t4
-a9 sequenceflow "a9" g3 g5
-a10 sequenceflow "a10" t4 g4
-a11 sequenceflow "a11" g4 t7
-a12 sequenceflow "a12" g5 t5
-a13 sequenceflow "a13" g5 t6
-a15 sequenceflow "a15" t5 g6
-a16 sequenceflow "a16" t6 g6
-a14 sequenceflow "a14" g6 g4
-a17 sequenceflow "a17" t7 g7
-a18 sequenceflow "a18" g7 g8
-a19 sequenceflow "a19" g8 t9
-a20 sequenceflow "a20" g7 t8
-a21 sequenceflow "a21" t8 g8
-a22 sequenceflow "a22" t9 e2
+.edges
+e1 t1 sequenceflow "a1"
+t1 g1 sequenceflow "a2" 
+g1 t2 sequenceflow "a3" 
+t2 g2 sequenceflow "a4"
+g2 t3 sequenceflow "a5" 
+t3 g3 sequenceflow "a6" 
+g2 g1 sequenceflow "a7" 
+g3 t4 sequenceflow "a8"
+g3 g5 sequenceflow "a9" 
+t4 g4 sequenceflow "a10" 
+g4 t7 sequenceflow "a11" 
+g5 t5 sequenceflow "a12"
+g5 t6 sequenceflow "a13"
+t5 g6 sequenceflow "a15"
+t6 g6 sequenceflow "a16"
+g6 g4 sequenceflow "a14"
+t7 g7 sequenceflow "a17"
+g7 g8 sequenceflow "a18" 
+g8 t9 sequenceflow "a19" 
+g7 t8 sequenceflow "a20"
+t8 g8 sequenceflow "a21"
+t9 e2 sequenceflow "a22"

--- a/src/assets/valid-graphs/BeispielSeite27_E2_T9_G8_A22.txt
+++ b/src/assets/valid-graphs/BeispielSeite27_E2_T9_G8_A22.txt
@@ -3,15 +3,15 @@ e1 start "e1"
 e2 end "e2"
 
 .tasks
-t1 none "Reise planen"
-t2 none "Antrag stellen"
-t3 none " Reise genehmigen"
-t4 none "Hotel buchen"
-t5 none "Flug buchen"
-t6 none "Bahn buchen"
-t7 none "Reise dokumentieren"
-t8 none "Vorauszahlung durchfuehren"
-t9 none "Reise durchfuehren"
+t1 "Reise planen"
+t2 "Antrag stellen"
+t3 " Reise genehmigen"
+t4 "Hotel buchen"
+t5 "Flug buchen"
+t6 "Bahn buchen"
+t7 "Reise dokumentieren"
+t8 "Vorauszahlung durchfuehren"
+t9 "Reise durchfuehren"
 
 .gateways 
 g1 xor_join

--- a/src/assets/valid-graphs/BeispielSeite50_E2_T6_G2_A10.txt
+++ b/src/assets/valid-graphs/BeispielSeite50_E2_T6_G2_A10.txt
@@ -1,8 +1,8 @@
 .events
-e1 start ""
+e1 start
 e2 end "Reise gebucht"
 
-.activities
+.tasks
 t1 usertask "Reise planen"
 t2 usertask "Flug suchen"
 t3 usertask "Hotel suchen"
@@ -12,20 +12,20 @@ t6 service "Reiseunterlagen speichern"
 
 
 .gateways 
-g1 and_split ""
-g2 and_join ""
+g1 and_split
+g2 and_join
 
-.sequences
-a1 sequenceflow "a1" e1 t1
-a2 sequenceflow "a2" t1 g1
-a3 sequenceflow "a3" g1 t2
-a4 sequenceflow "a4 " g1 t3
-a5 sequenceflow "a5" t2 t4
-a6 sequenceflow "a6" t3 t5
-a7 sequenceflow "a7" t4 g2
-a8 sequenceflow "a8" t5 g2
-a9 sequenceflow "a9" g2 t6
-a10 sequenceflow "a10" t6 e2
+.edges
+e1 t1 sequenceflow "a1"
+t1 g1 sequenceflow "a2"
+g1 t2 sequenceflow
+g1 t3 sequenceflow
+t2 t4 sequenceflow
+t3 t5 sequenceflow
+g2 t6 sequenceflow
+t6 e2 sequenceflow
+t4 g2 sequenceflow
+t5 g2 sequenceflow
 
 
 

--- a/src/assets/valid-graphs/BeispielSeite57_E7_T4_G2_A14.txt
+++ b/src/assets/valid-graphs/BeispielSeite57_E7_T4_G2_A14.txt
@@ -7,29 +7,29 @@ e5 intermediate "Buchungsbestaetigung ist erhalten"
 e6 intermediate "Buchungsbestaetigung ist erhalten"
 e7 end "Reise gebucht"
 
-.activities
+.tasks
 t1 usertask "Reise planen"
 t2 usertask "Flug suchen"
 t3 usertask " Hotel Suchen"
 t4 service "Reiseunterlagen speichern"
 
 .gateways 
-g1 xor_join ""
-g2 and_split ""
-g3 and_join ""
+g1 xor_join
+g2 and_split
+g3 and_join
 
-.sequences
-a1 sequenceflow "a1" e1 g1
-a2 sequenceflow "a2" e2 g1
-a3 sequenceflow "a3" g1 t1
-a4 sequenceflow "a4 " t1 g2
-a5 sequenceflow "a5" g2 t2
-a6 sequenceflow "a6" g2 t3
-a7 sequenceflow "a7" t2 e3
-a8 sequenceflow "a8" t3 e4
-a9 sequenceflow "a9" e3 e5
-a10 sequenceflow "a10" e4 e6
-a11 sequenceflow "a11" e5 g3
-a12 sequenceflow "a12" e6 g3
-a13 sequenceflow "a13" g3 t4
-a14 sequenceflow "a14" t4 e7
+.edges
+e1 g1 sequenceflow "a1" 
+e2 g1 sequenceflow "a2" 
+g1 t1 sequenceflow "a3" 
+t1 g2 sequenceflow "a4 " 
+g2 t2 sequenceflow "a5" 
+g2 t3 sequenceflow "a6" 
+t2 e3 sequenceflow "a7" 
+t3 e4 sequenceflow "a8"
+e3 e5 sequenceflow "a9"
+e4 e6 sequenceflow "a10" 
+e5 g3 sequenceflow "a11" 
+e6 g3 sequenceflow "a12" 
+g3 t4 sequenceflow "a13" 
+t4 e7 sequenceflow "a14" 

--- a/src/assets/valid-graphs/BeispielSeite60_E4_T5_G2_A12.txt
+++ b/src/assets/valid-graphs/BeispielSeite60_E4_T5_G2_A12.txt
@@ -4,7 +4,7 @@ e2 intermediate "Buchungsbestaetigung ist erhalten"
 e3 intermediate "Buchungsbestaetigung ist erhalten"
 e4 end "Reise gebucht"
 
-.activities
+.tasks
 t1 usertask "Flug suchen"
 t2 usertask " Hotel Suchen"
 t3 sending "Flug buchen"
@@ -12,19 +12,19 @@ t4 sending " Hotel buchen"
 t5 service "Reiseunterlagen speichern"
 
 .gateways 
-g1 or_split ""
-g2 or_join ""
+g1 or_split
+g2 or_join
 
-.sequences
-a1 sequenceflow "a1" e1 g1
-a2 sequenceflow "a2" g1 g2
-a3 sequenceflow "a3" g2 t5
-a4 sequenceflow "a4 " t5 e4
-a5 sequenceflow "a5" g1 t1
-a6 sequenceflow "a6" g1 t2
-a7 sequenceflow "a7" t1 t3
-a8 sequenceflow "a8" t2 t4
-a9 sequenceflow "a9" t3 e2
-a10 sequenceflow "a10" t4 e3
-a11 sequenceflow "a11" e2 g2
-a12 sequenceflow "a12" e3 g2
+.edges
+e1 g1 sequenceflow "a1" 
+g1 g2 sequenceflow "a2" 
+g2 t5 sequenceflow "a3" 
+t5 e4 sequenceflow "a4 " 
+g1 t1 sequenceflow "a5" 
+g1 t2 sequenceflow "a6" 
+t1 t3 sequenceflow "a7" 
+t2 t4 sequenceflow "a8"
+t3 e2 sequenceflow "a9" 
+t4 e3 sequenceflow "a10" 
+e2 g2 sequenceflow "a11" 
+e3 g2 sequenceflow "a12" 

--- a/src/assets/valid-graphs/BeispielSeite72b_E2_T4_G4_A11.txt
+++ b/src/assets/valid-graphs/BeispielSeite72b_E2_T4_G4_A11.txt
@@ -1,28 +1,28 @@
 .events
-e1 start ""
-e2 end ""
+e1 start
+e2 end
 
-.activities
+.tasks
 t1 none "Flug suchen"
 t2 none " Hotel Suchen"
 t3 none "Flug buchen"
 t4 none "Hotel buchen"
 
 .gateways 
-g1 xor_split ""
-g2 xor_join ""
-g3 xor_split ""
-g4 xor_join ""
+g1 xor_split
+g2 xor_join
+g3 xor_split
+g4 xor_join
 
-.sequences
-a1 sequenceflow "a1" e1 g1
-a2 sequenceflow "a2" g1 t1
-a3 sequenceflow "a3" g1 t2
-a4 sequenceflow "a4 " t1 g2
-a5 sequenceflow "a5" t2 g2
-a6 sequenceflow "a6" g2 g3
-a7 sequenceflow "a7" g3 t3
-a8 sequenceflow "a8" g3 t4
-a9 sequenceflow "a9" t3 g4
-a10 sequenceflow "a10" t4 g4
-a11 sequenceflow "a11" g4 e2
+.edges
+e1 g1 sequenceflow "a1" 
+g1 t1 sequenceflow "a2" 
+g1 t2 sequenceflow "a3"
+t1 g2 sequenceflow "a4" 
+t2 g2 sequenceflow "a5" 
+g2 g3 sequenceflow "a6" 
+g3 t3 sequenceflow "a7" 
+g3 t4 sequenceflow "a8" 
+t3 g4 sequenceflow "a9" 
+t4 g4 sequenceflow "a10" 
+g4 e2 sequenceflow "a11" 

--- a/src/assets/valid-graphs/BeispielSeite72b_E2_T4_G4_A11.txt
+++ b/src/assets/valid-graphs/BeispielSeite72b_E2_T4_G4_A11.txt
@@ -3,10 +3,10 @@ e1 start
 e2 end
 
 .tasks
-t1 none "Flug suchen"
-t2 none " Hotel Suchen"
-t3 none "Flug buchen"
-t4 none "Hotel buchen"
+t1 "Flug suchen"
+t2 " Hotel Suchen"
+t3 "Flug buchen"
+t4 "Hotel buchen"
 
 .gateways 
 g1 xor_split

--- a/src/assets/valid-graphs/BeispielSeite73b_E2_T4_G4_A11.txt
+++ b/src/assets/valid-graphs/BeispielSeite73b_E2_T4_G4_A11.txt
@@ -1,28 +1,28 @@
 .events
-e1 start ""
-e2 end ""
+e1 start
+e2 end
 
-.activities
+.tasks
 t1 none "Genehmigung einholen"
 t2 none " Reise planen"
 t3 none "Flug buchen"
 t4 none "Hotel buchen"
 
 .gateways 
-g1 xor_join ""
-g2 xor_split ""
-g3 and_split ""
-g4 and_join ""
+g1 xor_join
+g2 xor_split
+g3 and_split
+g4 and_join
 
-.sequences
-a1 sequenceflow "a1" e1 g1
-a2 sequenceflow "a2" g1 t1
-a3 sequenceflow "a3" t1 t2
-a4 sequenceflow "a4 " t2 g3
-a5 sequenceflow "a5" g3 t3
-a6 sequenceflow "a6" g3 t4
-a7 sequenceflow "a7" t3 g4
-a8 sequenceflow "a8" t4 g4
-a9 sequenceflow "a9" g4 g2
-a10 sequenceflow "a10" g2 e2
-a11 sequenceflow "a11" g2 g1
+.edges
+e1 g1 sequenceflow "a1" 
+g1 t1 sequenceflow "a2" 
+t1 t2 sequenceflow "a3" 
+t2 g3 sequenceflow "a4 " 
+g3 t3 sequenceflow "a5" 
+g3 t4 sequenceflow "a6" 
+t3 g4 sequenceflow "a7" 
+t4 g4 sequenceflow "a8" 
+g4 g2 sequenceflow "a9"
+g2 e2 sequenceflow "a10" 
+g2 g1 sequenceflow "a11" 

--- a/src/assets/valid-graphs/BeispielSeite73b_E2_T4_G4_A11.txt
+++ b/src/assets/valid-graphs/BeispielSeite73b_E2_T4_G4_A11.txt
@@ -3,10 +3,10 @@ e1 start
 e2 end
 
 .tasks
-t1 none "Genehmigung einholen"
-t2 none " Reise planen"
-t3 none "Flug buchen"
-t4 none "Hotel buchen"
+t1 "Genehmigung einholen"
+t2 " Reise planen"
+t3 "Flug buchen"
+t4 "Hotel buchen"
 
 .gateways 
 g1 xor_join

--- a/src/assets/valid-graphs/BeispielSeite79b_E2_T6_G4_A13.txt
+++ b/src/assets/valid-graphs/BeispielSeite79b_E2_T6_G4_A13.txt
@@ -3,12 +3,12 @@ e1 start
 e2 end
 
 .tasks
-t1 none " Reise planen"
-t2 none "Flug buchen"
-t3 none "Zug buchen"
-t4 none "Sitzplatz buchen"
-t5 none "Hotel buchen"
-t6 none "Vorgang archivieren"
+t1 " Reise planen"
+t2 "Flug buchen"
+t3 "Zug buchen"
+t4 "Sitzplatz buchen"
+t5 "Hotel buchen"
+t6 "Vorgang archivieren"
 
 
 .gateways 

--- a/src/assets/valid-graphs/BeispielSeite79b_E2_T6_G4_A13.txt
+++ b/src/assets/valid-graphs/BeispielSeite79b_E2_T6_G4_A13.txt
@@ -1,8 +1,8 @@
 .events
-e1 start ""
-e2 end ""
+e1 start
+e2 end
 
-.activities
+.tasks
 t1 none " Reise planen"
 t2 none "Flug buchen"
 t3 none "Zug buchen"
@@ -12,22 +12,22 @@ t6 none "Vorgang archivieren"
 
 
 .gateways 
-g1 xor_split ""
-g2 xor_join ""
-g3 and_split ""
-g4 and_join ""
+g1 xor_split
+g2 xor_join
+g3 and_split
+g4 and_join
 
-.sequences
-a1 sequenceflow "a1" e1 t1
-a2 sequenceflow "a2" t1 g1
-a3 sequenceflow "a3" g1 t2
-a4 sequenceflow "a4 " g1 g3
-a5 sequenceflow "a5" g3 t3
-a6 sequenceflow "a6" g3 t4
-a7 sequenceflow "a7" t3 g4
-a8 sequenceflow "a8" t4 g4
-a9 sequenceflow "a9" g4 g2
-a10 sequenceflow "a10" g2 t5
-a11 sequenceflow "a11" t5 t6
-a12 sequenceflow "a12" t6 e2
-a13 sequenceflow "a13" t2 g2
+.edges
+e1 t1 sequenceflow "a1" 
+t1 g1 sequenceflow "a2" 
+g1 t2 sequenceflow "a3" 
+g1 g3 sequenceflow "a4 " 
+g3 t3 sequenceflow "a5" 
+g3 t4 sequenceflow "a6" 
+t3 g4 sequenceflow "a7" 
+t4 g4 sequenceflow "a8" 
+g4 g2 sequenceflow "a9" 
+g2 t5 sequenceflow "a10" 
+t5 t6 sequenceflow "a11" 
+t6 e2 sequenceflow "a12" 
+t2 g2 sequenceflow "a13" 

--- a/src/assets/valid-graphs/E2_T7_G6_A17_working.txt
+++ b/src/assets/valid-graphs/E2_T7_G6_A17_working.txt
@@ -2,7 +2,7 @@
 e1 start "Start"
 e2 end "Ende"
 
-.activities
+.tasks
 t1 service "BpmnTaskService t1"
 t2 manual "BpmnTaskManual t2"
 t3 usertask "BpmnTaskUser t3"
@@ -12,28 +12,28 @@ t6 usertask "BpmnTaskUser t6"
 t7 usertask "BpmnTaskUser t7"
 
 .gateways 
-g1 or_split ""
-g2 or_join ""
-g3 and_split ""
-g4 and_join ""
-g5 xor_split ""
-g6 xor_join ""
+g1 or_split
+g2 or_join
+g3 and_split
+g4 and_join
+g5 xor_split
+g6 xor_join
 
-.sequences
-connector1 sequenceflow "a1" e1 t1
-connector2 sequenceflow "a2" t1 g1
-connector3 sequenceflow "a3" g1 t2
-connector4 sequenceflow "a4" g1 t3
-connector5 sequenceflow "a5" t2 g3
-connector6 sequenceflow "a6" g3 t4
-connector7 sequenceflow "a7" g3 t5
-connector8 sequenceflow "a8" t4 g4
-connector9 sequenceflow "a9" t5 g4
-connector10 sequenceflow "a10" t3 g5
-connector11 sequenceflow "a11" g5 t6
-connector12 sequenceflow "a12" g5 t7
-connector13 sequenceflow "a13" t6 g6
-connector14 sequenceflow "a14" t7 g6
-connector15 sequenceflow "a15" g4 g2
-connector16 sequenceflow "a16" g6 g2
-connector17 sequenceflow "a17" g2 e2
+.edges
+e1 t1 sequenceflow "a1" 
+t1 g1 sequenceflow "a2" 
+g1 t2 sequenceflow "a3" 
+g1 t3 sequenceflow "a4" 
+t2 g3 sequenceflow "a5" 
+g3 t4 sequenceflow "a6" 
+g3 t5 sequenceflow "a7" 
+t4 g4 sequenceflow "a8" 
+t5 g4 sequenceflow "a9" 
+t3 g5 sequenceflow "a10" 
+g5 t6 sequenceflow "a11" 
+g5 t7 sequenceflow "a12" 
+t6 g6 sequenceflow "a13" 
+t7 g6 sequenceflow "a14" 
+g4 g2 sequenceflow "a15" 
+g6 g2 sequenceflow "a16" 
+g2 e2 sequenceflow "a17" 

--- a/src/assets/valid-graphs/E3_G2_A7_working.txt
+++ b/src/assets/valid-graphs/E3_G2_A7_working.txt
@@ -2,20 +2,20 @@
 e1 start "Start"
 e2 end "Ende"
 
-.activities
+.tasks
 t1 service "BpmnTaskService"
 t2 manual "BpmnTaskManual"
 t3 usertask "BpmnTaskUser"
 
 .gateways 
-g1 or_split ""
-g2 or_join ""
+g1 or_split
+g2 or_join
 
-.sequences
-connector1 sequenceflow "a1" e1 t1
-connector2 sequenceflow "a2" t1 g1
-connector3 sequenceflow "a3" g1 t2
-connector4 sequenceflow "a4" g1 t3
-connector5 sequenceflow "a5" t2 g2
-connector6 sequenceflow "a6" t3 g2
-connector7 sequenceflow "a7" g2 e2
+.edges
+e1 t1 sequenceflow "a1" 
+t1 g1 sequenceflow "a2" 
+g1 t2 sequenceflow "a3" 
+g1 t3 sequenceflow "a4" 
+t2 g2 sequenceflow "a5" 
+t3 g2 sequenceflow "a6" 
+g2 e2 sequenceflow "a7" 

--- a/src/assets/valid-graphs/E3_T8_G6_A19_working.txt
+++ b/src/assets/valid-graphs/E3_T8_G6_A19_working.txt
@@ -3,7 +3,7 @@ e1 start "Start"
 e2 intermediate "Pause"
 e3 end "Ende"
 
-.activities
+.tasks
 t1 service "BpmnTaskService t1"
 t2 manual "BpmnTaskManual t2"
 t3 usertask "BpmnTaskUser t3"
@@ -15,30 +15,30 @@ t8 service "BpmnTaskService t8"
 
 
 .gateways 
-g1 or_split ""
-g2 or_join ""
-g3 and_split ""
-g4 and_join ""
-g5 xor_split ""
-g6 xor_join ""
+g1 or_split
+g2 or_join
+g3 and_split
+g4 and_join
+g5 xor_split
+g6 xor_join
 
-.sequences
-connector1 sequenceflow "a1" e1 t1
-connector2 sequenceflow "a2" t1 g1
-connector3 sequenceflow "a3" g1 t2
-connector4 sequenceflow "a4" g1 t3
-connector5 sequenceflow "a5" t2 g3
-connector6 sequenceflow "a6" g3 t4
-connector7 sequenceflow "a7" g3 t5
-connector8 sequenceflow "a8" t4 g4
-connector9 sequenceflow "a9" t5 g4
-connector10 sequenceflow "a10" t3 g5
-connector11 sequenceflow "a11" g5 t6
-connector12 sequenceflow "a12" g5 t7
-connector13 sequenceflow "a13" t6 g6
-connector14 sequenceflow "a14" t7 g6
-connector15 sequenceflow "a15" g4 g2
-connector16 sequenceflow "a16" g6 g2
-connector17 sequenceflow "a17" g2 e2
-connector18 sequenceflow "a18" e2 t8
-connector19 sequenceflow "a19" t8 e3
+.edges
+e1 t1 sequenceflow "a1" 
+t1 g1 sequenceflow "a2"
+g1 t2 sequenceflow "a3" 
+g1 t3 sequenceflow "a4" 
+t2 g3 sequenceflow "a5" 
+g3 t4 sequenceflow "a6" 
+g3 t5 sequenceflow "a7" 
+t4 g4 sequenceflow "a8" 
+t5 g4 sequenceflow "a9" 
+t3 g5 sequenceflow "a10" 
+g5 t6 sequenceflow "a11" 
+g5 t7 sequenceflow "a12" 
+t6 g6 sequenceflow "a13" 
+t7 g6 sequenceflow "a14" 
+g4 g2 sequenceflow "a15" 
+g6 g2 sequenceflow "a16" 
+g2 e2 sequenceflow "a17" 
+e2 t8 sequenceflow "a18" 
+t8 e3 sequenceflow "a19" 

--- a/src/assets/valid-graphs/anotherMonsterGraph.txt
+++ b/src/assets/valid-graphs/anotherMonsterGraph.txt
@@ -6,7 +6,7 @@ e3 end "E3 Ende"
 .tasks
 t1 manual "T1"
 t2 usertask "T2"
-t3 none "T3"
+t3 "T3"
 t4 usertask "T4"
 t5 usertask "T5"
 t6 usertask "T6"

--- a/src/assets/valid-graphs/anotherMonsterGraph.txt
+++ b/src/assets/valid-graphs/anotherMonsterGraph.txt
@@ -3,23 +3,23 @@ e1 start "E1 Start1"
 e2 start "E2 Start2"
 e3 end "E3 Ende"
 
-.activities
-t1 none "T1"
-t2 none "T2"
+.tasks
+t1 manual "T1"
+t2 usertask "T2"
 t3 none "T3"
-t4 none "T4"
-t5 none "T5"
-t6 none "T6"
-t7 none "T7"
-t8 none "T8"
-t9 none "T9"
-t10 none "T10"
-t11 none "T11"
-t12 none "T12"
-t13 none "T13"
-t14 none "T14"
-t15 none "T15"
-t16 none "T16"
+t4 usertask "T4"
+t5 usertask "T5"
+t6 usertask "T6"
+t7 usertask "T7"
+t8 usertask "T8"
+t9 usertask "T9"
+t10 manual "T10"
+t11 service "T11"
+t12 usertask "T12"
+t13 manual "T13"
+t14 usertask "T14"
+t15 manual "T15"
+t16 service "T16"
 
 .gateways
 g1J or_join "G1J"
@@ -36,41 +36,41 @@ g6J xor_join "G6J"
 g7S or_split "G7S"
 g7J or_join "G7J"
 
-.sequences
-a1 sequenceflow "a1" e1 t1      
-a2 sequenceflow "a2" t1 g1J 
-a3 sequenceflow "a3" e2 g1J 
-a4 sequenceflow "a4" g1J t2
-a5 sequenceflow "a5" t2 g2S
-a6 sequenceflow "a6" g2S t3
-a7 sequenceflow "a7" t3 g3S
-a8 sequenceflow "a8" g3S t6
-a9 sequenceflow "a9" t6 g6S
-a10 sequenceflow "a10" g6S t7
-a11 sequenceflow "a11" g6S t8
-a12 sequenceflow "a12" t7 t15
-a13 sequenceflow "a13" t8 t16
-a15 sequenceflow "a15" t15 g6J
-a16 sequenceflow "a16" t16 g6J
-a14 sequenceflow "a14" g6J g3J
-a17 sequenceflow "a17" g3S t9
-a18 sequenceflow "a18" t9 g7S
-a19 sequenceflow "a19" g7S t10
-a20 sequenceflow "a20" g7S t11
-a21 sequenceflow "a21" t10 g7J
-a22 sequenceflow "a22" t11 g7J
-a23 sequenceflow "a23" g7J g3J
-a24 sequenceflow "a24" g2S g4S
-a25 sequenceflow "a25" g4S t4
-a26 sequenceflow "a26" t4 t12
-a27 sequenceflow "a27" t12 g4J
-a28 sequenceflow "a28" g4S t5
-a29 sequenceflow "a29" t5 g5S
-a30 sequenceflow "a30" g5S t13
-a31 sequenceflow "a31" g5S t14
-a32 sequenceflow "a32" t13 g5J
-a33 sequenceflow "a33" t14 g5J
-a34 sequenceflow "a34" g5J g4J
-a35 sequenceflow "a35" g3J g2J
-a36 sequenceflow "a36" g4J g2J
-a37 sequenceflow "a37" g2J e3
+.edges
+e1 t1 sequenceflow    
+t1 g1J sequenceflow 
+e2 g1J sequenceflow "a3" 
+g1J t2 sequenceflow
+t2 g2S sequenceflow
+g2S t3 sequenceflow
+t3 g3S sequenceflow
+g3S t6 sequenceflow
+t6 g6S sequenceflow
+g6S t7 sequenceflow
+g6S t8 sequenceflow "t8"
+t7 t15 sequenceflow
+t8 t16 sequenceflow
+t15 g6J sequenceflow
+t16 g6J sequenceflow
+g6J g3J sequenceflow
+g3S t9 sequenceflow
+t9 g7S sequenceflow
+g7S t10 sequenceflow
+g7S t11 sequenceflow
+t10 g7J sequenceflow
+t11 g7J sequenceflow
+g7J g3J sequenceflow
+g2S g4S sequenceflow
+g4S t4 sequenceflow
+t4 t12 sequenceflow
+t12 g4J sequenceflow
+g4S t5 sequenceflow
+t5 g5S sequenceflow
+g5S t13 sequenceflow
+g5S t14 sequenceflow
+t13 g5J sequenceflow
+t14 g5J sequenceflow
+g5J g4J sequenceflow
+g3J g2J sequenceflow
+g4J g2J sequenceflow
+g2J e3 sequenceflow

--- a/src/assets/valid-graphs/simple-and-graph.txt
+++ b/src/assets/valid-graphs/simple-and-graph.txt
@@ -1,27 +1,26 @@
 .events
-e1 start "StartEvent" (60,190)
-e2 intermediate "IntermEvent" (1600,190)
-e3 end "EndEvent" (1600,190)
+e1 start "StartEvent"
+e2 intermediate "IntermEvent"
+e3 end "EndEvent"
 
-
-.activities
-t1 service "Service" (442,60)
-t2 manual "ManualTask" (442,320)
-t3 usertask "UserTask" (1225,190)
+.tasks
+t1 service "Service"
+t2 manual "ManualTask"
+t3 usertask "UserTask"
 
 .gateways 
-g1 and_split "ANDSplit" (210,190)
-g2 and_join "ANDJoin" (675,190)
+g1 and_split "ANDSplit"
+g2 and_join "ANDJoin"
 
-.sequences
-connector1 sequenceflow "1" e1 t1
-connector2 sequenceflow "p3" t1 g1 (210,320)
-connector3 sequenceflow "a4" g1 t2 (675,60)
-connector4 sequenceflow "a5" g1 t3 (675,320)
-connector5 sequenceflow "a6" t2 g2 
-connector6 sequenceflow "a7" t3 g2
-connector7 sequenceflow "a8" g2 e2
-connector8 sequenceflow "8" e2 e3
+.edges
+e1 t1 sequenceflow "1" 
+t1 g1 sequenceflow "p3"
+g1 t2 sequenceflow "a4" 
+g1 t3 sequenceflow "a5"
+t2 g2 sequenceflow "a6" 
+t3 g2 sequenceflow "a7" 
+g2 e2 sequenceflow "a8" 
+e2 e3 sequenceflow "8" 
  
 
 

--- a/src/assets/valid-graphs/simple-graph-no-gateways.txt
+++ b/src/assets/valid-graphs/simple-graph-no-gateways.txt
@@ -2,15 +2,15 @@
 StartEv start "StartEvent" (60,190)
 EndEvent end "EndEvent" (1600,190)
 
-.activities
+.tasks
 ServiceTask service "ServiceTask" (442,60)
 
 .gateways 
 
 
-.sequences
-connector1 sequenceflow "1" StartEv ServiceTask
-connector7 sequenceflow "2" ServiceTask EndEvent
+.edges
+StartEv ServiceTask sequenceflow "1" 
+ServiceTask EndEvent sequenceflow "2" 
 
  
 

--- a/src/assets/valid-graphs/simple-or-graph.txt
+++ b/src/assets/valid-graphs/simple-or-graph.txt
@@ -6,6 +6,7 @@ EndEvent end "EndEvent" (1600,190)
 BRTask businessrule "BusinessRule" (442,60)
 ManualTask manual "ManualTask" (442,320)
 UserTask usertask "UserTask" (442,190)
+
 .gateways 
 ORSplit or_split "ORSplit" (210,190)
 ORJoin or_join "ORJoin" (675,190)

--- a/src/assets/valid-graphs/simple-or-graph.txt
+++ b/src/assets/valid-graphs/simple-or-graph.txt
@@ -2,23 +2,22 @@
 StartEv start "StartEvent" (60,190)
 EndEvent end "EndEvent" (1600,190)
 
-.activities
+.tasks
 BRTask businessrule "BusinessRule" (442,60)
 ManualTask manual "ManualTask" (442,320)
-UserTask usertask "UserTask" (1225,190)
-
+UserTask usertask "UserTask" (442,190)
 .gateways 
 ORSplit or_split "ORSplit" (210,190)
 ORJoin or_join "ORJoin" (675,190)
 
-.sequences
-connector1 sequenceflow "1" StartEv BRTask
-connector2 sequenceflow "2" BRTask ORSplit (210,320)
-connector3 sequenceflow "3" ORSplit ManualTask (675,60)
-connector4 sequenceflow "4" ORSplit UserTask (675,320)
-connector5 sequenceflow "5" ManualTask ORJoin 
-connector6 sequenceflow "6" UserTask ORJoin
-connector7 sequenceflow "7" ORJoin EndEvent
+.edges
+StartEv BRTask sequenceflow "1" 
+BRTask ORSplit sequenceflow "2"
+ORSplit ManualTask sequenceflow "3"
+ORSplit UserTask sequenceflow "4"
+ManualTask ORJoin sequenceflow "5" 
+UserTask ORJoin sequenceflow "6" 
+ORJoin EndEvent sequenceflow "7"
 
  
 

--- a/src/assets/valid-graphs/simple-xor-graph.txt
+++ b/src/assets/valid-graphs/simple-xor-graph.txt
@@ -2,23 +2,23 @@
 StartEv start "StartEvent" (60,190)
 EndEvent end "EndEvent" (1600,190)
 
-.activities
+.tasks
 ServiceTask service "ServiceTask" (442,60)
 ManualTask manual "ManualTask" (442,320)
-UserTask usertask "UserTask" (1225,190)
+UserTask usertask "UserTask" (442,190)
 
 .gateways 
 XORSplit xor_split "XORSplit" (210,190)
 XORJoin xor_join "XORJoin" (675,190)
 
-.sequences
-connector1 sequenceflow "1" StartEv ServiceTask
-connector2 sequenceflow "2" ServiceTask XORSplit (210,320)
-connector3 sequenceflow "3" XORSplit ManualTask (675,60)
-connector4 sequenceflow "4" XORSplit UserTask (675,320)
-connector5 sequenceflow "5" ManualTask XORJoin 
-connector6 sequenceflow "6" UserTask XORJoin
-connector7 sequenceflow "7" XORJoin EndEvent
+.edges
+StartEv ServiceTask sequenceflow "1" 
+ServiceTask XORSplit sequenceflow "2"
+XORSplit ManualTask sequenceflow "3"
+XORSplit UserTask sequenceflow "4"
+ManualTask XORJoin sequenceflow "5" 
+UserTask XORJoin sequenceflow "6" 
+XORJoin EndEvent sequenceflow "7" 
 
  
 

--- a/src/assets/valid-graphs/xor-sequence-and.txt
+++ b/src/assets/valid-graphs/xor-sequence-and.txt
@@ -1,34 +1,34 @@
 .events
-e1 start "StartEvent" (60,190)
-e2 end "EndEvent" (1600,190)
+e1 start "StartEvent"
+e2 end "EndEvent"
 
-.activities
-t1 sending "SendingTask" (442,60)
-t2 receiving "ReceiveTask" (442,320)
-t3 usertask "UserTask" (1225,190)
-t4 service "Service" (1225,190)
-t5 manual "ManualTask" (1225,190)
-t6 usertask "UserTask2" (1225,190)
+.tasks
+t1 sending "SendingTask"
+t2 receiving "ReceiveTask"
+t3 usertask "UserTask"
+t4 service "Service"
+t5 manual "ManualTask"
+t6 usertask "UserTask2"
 
 .gateways 
-g1 xor_split "XORSplit" (210,190)
-g2 xor_join "XORJoin" (675,190)
-g3 and_split "ANDSplit" (210,190)
-g4 and_join "ANDJoin" (675,190)
+g1 xor_split "XORSplit"
+g2 xor_join "XORJoin"
+g3 and_split "ANDSplit"
+g4 and_join "ANDJoin"
 
-.sequences
-connector1 sequenceflow "1" e1 g1
-connector2 sequenceflow "2" g1 t1
-connector3 sequenceflow "3" t1 g2
-connector4 sequenceflow "4" g1 t2
-connector5 sequenceflow "5" t2 g2
-connector6 sequenceflow "6" g2 t3
-connector7 sequenceflow "7" t3 g3
-connector8 sequenceflow "8" g3 t4
-connector9 sequenceflow "9" t4 g4
-connector10 sequenceflow "10" g3 t5
-connector11 sequenceflow "11" t5 t6
-connector12 sequenceflow "12" t6 g4
-connector13 sequenceflow "13" g4 e2
+.edges
+e1 g1 sequenceflow "1" 
+g1 t1 sequenceflow "2" 
+t1 g2 sequenceflow "3" 
+g1 t2 sequenceflow "4" 
+t2 g2 sequenceflow "5" 
+g2 t3 sequenceflow "6" 
+t3 g3 sequenceflow "7" 
+g3 t4 sequenceflow "8" 
+t4 g4 sequenceflow "9" 
+g3 t5 sequenceflow "10"
+t5 t6 sequenceflow "11" 
+t6 g4 sequenceflow "12" 
+g4 e2 sequenceflow "13" 
 
 

--- a/src/assets/valid-graphs/xor-with-nested-and.txt
+++ b/src/assets/valid-graphs/xor-with-nested-and.txt
@@ -1,32 +1,31 @@
 .events
-e1 start "StartEvent" (60,190)
-e2 end "EndEvent" (1600,190)
+e1 start "StartEvent"
+e2 end "EndEvent"
 
-.activities
-t1 sending "SendingTask" (442,60)
-t2 receiving "ReceiveTask" (442,320)
-t3 usertask "UserTask" (1225,190)
-t4 service "Service" (1225,190)
-t5 manual "ManualTask" (1225,190)
+.tasks
+t1 sending "SendingTask"
+t2 receiving "ReceiveTask"
+t3 usertask "UserTask"
+t4 service "Service"
+t5 manual "ManualTask"
 
 .gateways 
-g1 xor_split "XORSplit" (210,190)
-g2 xor_join "XORJoin" (675,190)
-g3 and_split "ANDSplit" (210,190)
-g4 and_join "ANDJoin" (675,190)
+g1 xor_split "XORSplit"
+g2 xor_join "XORJoin"
+g3 and_split "ANDSplit"
+g4 and_join "ANDJoin"
 
-.sequences
-connector1 sequenceflow "1" e1 g1
-connector2 sequenceflow "2" g1 t1
-connector3 sequenceflow "3" t1 g2
-connector4 sequenceflow "4" g1 t2
-connector5 sequenceflow "5" t2 g3
-connector6 sequenceflow "6" g3 t3
-connector7 sequenceflow "7" g3 t4
-connector8 sequenceflow "8" t3 g4
-connector9 sequenceflow "9" t4 g4
-connector10 sequenceflow "10" g4 g2
-connector11 sequenceflow "11" g2 t5
-connector12 sequenceflow "12" t5 e2
-
+.edges
+e1 g1 sequenceflow "1"
+g1 t1 sequenceflow "2" 
+t1 g2 sequenceflow "3" 
+g1 t2 sequenceflow "4" 
+t2 g3 sequenceflow "5" 
+g3 t3 sequenceflow "6" 
+g3 t4 sequenceflow "7" 
+t3 g4 sequenceflow "8"
+t4 g4 sequenceflow "9" 
+g4 g2 sequenceflow "10"
+g2 t5 sequenceflow "11" 
+t5 e2 sequenceflow "12" 
 


### PR DESCRIPTION
-Textmodell-Änderung: Umbenennung zu tasks und edges, Labels optional, Vereinfachung edges
-Anpassen der Beispielgraphen in assets
-Anzeige Textspezifikation unterhalb des Textfelds
-Koordinaten inkludiert im BPMN-Export
-Import mit Koordinaten oder Eingeben von Koordinaten wird im Diagramm übernommen
-Änderungen im Diagramm durch Dragging werden ins Textfeld übernommen
-bei Umschalten auf Sugiyama-Modus zurücksetzen der Koordinaten im Textfeld